### PR TITLE
Feat/segment io renaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Gemfile.lock
 .ruby-version
 coverage/
+.vscode/

--- a/History.md
+++ b/History.md
@@ -168,7 +168,7 @@
 
 2.0.1 / 2014-05-15
 ==================
-* add: namespace under Segment::Analytics
+* add: namespace under SegmentIO::Analytics
 * add: can create multiple instances with creator method (rather than
     having a singleton)
 * add: logging with Logger instance or Rails.logger if available

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 analytics-ruby
 ==============
 
+## Note
+- This fork is meant to be a way to handle conflict namespaces with a class ```Segment``` and the gem internal class ```Segment```. It contains a ```build.sh``` script that should be run against the original gem whenever there's a new version, and then the resulting files should be commited and pushed to this fork. Internally it mantains the same functionality
+
+====================================================
+
 analytics-ruby is a ruby client for [Segment](https://segment.com)
 
 <div align="center">
@@ -61,7 +66,7 @@ gem install 'analytics-ruby'
 
 Create an instance of the Analytics object:
 ```ruby
-analytics = Segment::Analytics.new(write_key: 'YOUR_WRITE_KEY')
+analytics = SegmentIO::Analytics.new(write_key: 'YOUR_WRITE_KEY')
 ```
 
 Identify the user for the people section, see more [here](https://segment.com/docs/libraries/ruby/#identify).
@@ -92,18 +97,18 @@ Documentation is available at [segment.com/docs/sources/server/ruby](https://seg
 
 ## Testing
 
-You can use the `stub: true` option to Segment::Analytics.new to cause all requests to be stubbed, making it easier to test with this library.
+You can use the `stub: true` option to SegmentIO::Analytics.new to cause all requests to be stubbed, making it easier to test with this library.
 
 ### Test Queue
 
-You can use the `test: true` option to Segment::Analytics.new to cause all requests to be saved to a test queue until manually reset. All events will process as specified by the configuration, and they will also be stored in a separate queue for inspection during testing.
+You can use the `test: true` option to SegmentIO::Analytics.new to cause all requests to be saved to a test queue until manually reset. All events will process as specified by the configuration, and they will also be stored in a separate queue for inspection during testing.
 
 A test queue can be used as follows:
 
 ```ruby
-client = Segment::Analytics.new(test: true)
+client = SegmentIO::Analytics.new(test: true)
 
-client.test_queue # => #<Segment::Analytics::TestQueue:0x00007f88d454e9a8 @messages={}>
+client.test_queue # => #<SegmentIO::Analytics::TestQueue:0x00007f88d454e9a8 @messages={}>
 
 client.track(user_id: 'foo', event: 'bar')
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@ Pre-releases
 ============
 
 - Make sure you're on the latest `master`
-- Bump the version in [`version.rb`](lib/segment/analytics/version.rb)
+- Bump the version in [`version.rb`](lib/segment_io/analytics/version.rb)
 - Update [`History.md`](History.md)
 - Commit these changes. `git commit -am "Release x.y.z.pre"`
 - Tag the pre-release. `git tag -a -m "Version x.y.z.pre" x.y.z.pre`
@@ -18,7 +18,7 @@ Promoting pre-releases
 - Find the tag for the pre-release you want to promote. Use `git tag --list
   '*.pre'` to list all pre-release tags
 - Checkout that tag. `git checkout tags/x.y.z.pre`
-- Update the version in [`version.rb`](lib/segment/analytics/version.rb) to not
+- Update the version in [`version.rb`](lib/segment_io/analytics/version.rb) to not
   include the `.pre` suffix
 - Commit these changes. `git commit -am "Promote x.y.z.pre"`
 - Tag the release. `git tag -a -m "Version x.y.z" x.y.z`

--- a/analytics-ruby.gemspec
+++ b/analytics-ruby.gemspec
@@ -1,8 +1,8 @@
-require File.expand_path('../lib/segment/analytics/version', __FILE__)
+require File.expand_path('../lib/segment_io/analytics/version', __FILE__)
 
 Gem::Specification.new do |spec|
   spec.name = 'analytics-ruby'
-  spec.version = Segment::Analytics::VERSION
+  spec.version = SegmentIO::Analytics::VERSION
   spec.files = Dir.glob("{lib,bin}/**/*")
   spec.require_paths = ['lib']
   spec.bindir = 'bin'

--- a/bin/analytics
+++ b/bin/analytics
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require 'segment/analytics'
+require 'segment_io/analytics'
 require 'rubygems'
 require 'commander/import'
 require 'time'
@@ -42,7 +42,7 @@ command :send do |c|
   c.option '--previousId=<previousId>', String, 'the previous id'
 
   c.action do |args, options|
-    Analytics = Segment::Analytics.new({
+    Analytics = SegmentIO::Analytics.new({
       write_key: options.writeKey,
       on_error: Proc.new { |status, msg| print msg }
     })

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+echo "=== Starting project setup for namespace changes ==="
+echo "=== Renaming mentions ==="
+find . -type f -not -path '*/\.git/*' -not -path './\build.sh' -exec sed -i '' -e "s@module Segment@module SegmentIO@g" {} \;
+find . -type f -not -path '*/\.git/*' -not -path './\build.sh' -exec sed -i '' -e "s@require 'segment@require 'segment_io@g" {} \;
+find . -type f -not -path '*/\.git/*' -not -path './\build.sh' -exec sed -i '' -e "s@Segment::@SegmentIO::@g" {} \;
+find . -type f -not -path '*/\.git/*' -not -path './\build.sh' -exec sed -i '' -e "s@lib/segment/@lib/segment_io/@g" {} \;
+
+echo "=== Renaming files ==="
+mv spec/segment spec/segment_io
+mv lib/segment lib/segment_io
+echo "=== Installing dependencies ==="
+bundle install
+echo "=== Running tests ==="
+bundle exec rspec spec
+echo "Replace finished"
+

--- a/lib/analytics-ruby.rb
+++ b/lib/analytics-ruby.rb
@@ -1,1 +1,1 @@
-require 'segment'
+require 'segment_io'

--- a/lib/segment.rb
+++ b/lib/segment.rb
@@ -1,1 +1,1 @@
-require 'segment/analytics'
+require 'segment_io/analytics'

--- a/lib/segment_io/analytics.rb
+++ b/lib/segment_io/analytics.rb
@@ -1,26 +1,26 @@
-require 'segment/analytics/version'
-require 'segment/analytics/defaults'
-require 'segment/analytics/utils'
-require 'segment/analytics/field_parser'
-require 'segment/analytics/client'
-require 'segment/analytics/worker'
-require 'segment/analytics/transport'
-require 'segment/analytics/response'
-require 'segment/analytics/logging'
-require 'segment/analytics/test_queue'
+require 'segment_io/analytics/version'
+require 'segment_io/analytics/defaults'
+require 'segment_io/analytics/utils'
+require 'segment_io/analytics/field_parser'
+require 'segment_io/analytics/client'
+require 'segment_io/analytics/worker'
+require 'segment_io/analytics/transport'
+require 'segment_io/analytics/response'
+require 'segment_io/analytics/logging'
+require 'segment_io/analytics/test_queue'
 
-module Segment
+module SegmentIO
   class Analytics
-    # Initializes a new instance of {Segment::Analytics::Client}, to which all
+    # Initializes a new instance of {SegmentIO::Analytics::Client}, to which all
     # method calls are proxied.
     #
     # @param options includes options that are passed down to
-    #   {Segment::Analytics::Client#initialize}
+    #   {SegmentIO::Analytics::Client#initialize}
     # @option options [Boolean] :stub (false) If true, requests don't hit the
     #   server and are stubbed to be successful.
     def initialize(options = {})
       Transport.stub = options[:stub] if options.has_key?(:stub)
-      @client = Segment::Analytics::Client.new options
+      @client = SegmentIO::Analytics::Client.new options
     end
 
     def method_missing(message, *args, &block)

--- a/lib/segment_io/analytics/backoff_policy.rb
+++ b/lib/segment_io/analytics/backoff_policy.rb
@@ -1,9 +1,9 @@
-require 'segment/analytics/defaults'
+require 'segment_io/analytics/defaults'
 
-module Segment
+module SegmentIO
   class Analytics
     class BackoffPolicy
-      include Segment::Analytics::Defaults::BackoffPolicy
+      include SegmentIO::Analytics::Defaults::BackoffPolicy
 
       # @param [Hash] opts
       # @option opts [Numeric] :min_timeout_ms The minimum backoff timeout

--- a/lib/segment_io/analytics/client.rb
+++ b/lib/segment_io/analytics/client.rb
@@ -1,16 +1,16 @@
 require 'thread'
 require 'time'
 
-require 'segment/analytics/defaults'
-require 'segment/analytics/logging'
-require 'segment/analytics/utils'
-require 'segment/analytics/worker'
+require 'segment_io/analytics/defaults'
+require 'segment_io/analytics/logging'
+require 'segment_io/analytics/utils'
+require 'segment_io/analytics/worker'
 
-module Segment
+module SegmentIO
   class Analytics
     class Client
-      include Segment::Analytics::Utils
-      include Segment::Analytics::Logging
+      include SegmentIO::Analytics::Utils
+      include SegmentIO::Analytics::Logging
 
       # @param [Hash] opts
       # @option opts [String] :write_key Your project's write_key

--- a/lib/segment_io/analytics/defaults.rb
+++ b/lib/segment_io/analytics/defaults.rb
@@ -1,4 +1,4 @@
-module Segment
+module SegmentIO
   class Analytics
     module Defaults
       module Request

--- a/lib/segment_io/analytics/field_parser.rb
+++ b/lib/segment_io/analytics/field_parser.rb
@@ -1,11 +1,11 @@
-module Segment
+module SegmentIO
   class Analytics
     # Handles parsing fields according to the Segment Spec
     #
     # @see https://segment.com/docs/spec/
     class FieldParser
       class << self
-        include Segment::Analytics::Utils
+        include SegmentIO::Analytics::Utils
 
         # In addition to the common fields, track accepts:
         #
@@ -170,7 +170,7 @@ module Segment
         end
 
         def add_context!(context)
-          context[:library] = { :name => 'analytics-ruby', :version => Segment::Analytics::VERSION.to_s }
+          context[:library] = { :name => 'analytics-ruby', :version => SegmentIO::Analytics::VERSION.to_s }
         end
 
         # private: Ensures that a string is non-empty

--- a/lib/segment_io/analytics/logging.rb
+++ b/lib/segment_io/analytics/logging.rb
@@ -1,6 +1,6 @@
 require 'logger'
 
-module Segment
+module SegmentIO
   class Analytics
     # Wraps an existing logger and adds a prefix to all messages
     class PrefixedLogger
@@ -35,7 +35,7 @@ module Segment
                           Rails.logger
                         else
                           logger = Logger.new STDOUT
-                          logger.progname = 'Segment::Analytics'
+                          logger.progname = 'SegmentIO::Analytics'
                           logger
                         end
           @logger = PrefixedLogger.new(base_logger, '[analytics-ruby]')

--- a/lib/segment_io/analytics/message_batch.rb
+++ b/lib/segment_io/analytics/message_batch.rb
@@ -1,15 +1,15 @@
 require 'forwardable'
-require 'segment/analytics/logging'
+require 'segment_io/analytics/logging'
 
-module Segment
+module SegmentIO
   class Analytics
     # A batch of `Message`s to be sent to the API
     class MessageBatch
       class JSONGenerationError < StandardError; end
 
       extend Forwardable
-      include Segment::Analytics::Logging
-      include Segment::Analytics::Defaults::MessageBatch
+      include SegmentIO::Analytics::Logging
+      include SegmentIO::Analytics::Defaults::MessageBatch
 
       def initialize(max_message_count)
         @messages = []

--- a/lib/segment_io/analytics/response.rb
+++ b/lib/segment_io/analytics/response.rb
@@ -1,4 +1,4 @@
-module Segment
+module SegmentIO
   class Analytics
     class Response
       attr_reader :status, :error

--- a/lib/segment_io/analytics/test_queue.rb
+++ b/lib/segment_io/analytics/test_queue.rb
@@ -1,4 +1,4 @@
-module Segment
+module SegmentIO
   class Analytics
     class TestQueue
       attr_reader :messages

--- a/lib/segment_io/analytics/transport.rb
+++ b/lib/segment_io/analytics/transport.rb
@@ -1,18 +1,18 @@
-require 'segment/analytics/defaults'
-require 'segment/analytics/utils'
-require 'segment/analytics/response'
-require 'segment/analytics/logging'
-require 'segment/analytics/backoff_policy'
+require 'segment_io/analytics/defaults'
+require 'segment_io/analytics/utils'
+require 'segment_io/analytics/response'
+require 'segment_io/analytics/logging'
+require 'segment_io/analytics/backoff_policy'
 require 'net/http'
 require 'net/https'
 require 'json'
 
-module Segment
+module SegmentIO
   class Analytics
     class Transport
-      include Segment::Analytics::Defaults::Request
-      include Segment::Analytics::Utils
-      include Segment::Analytics::Logging
+      include SegmentIO::Analytics::Defaults::Request
+      include SegmentIO::Analytics::Utils
+      include SegmentIO::Analytics::Logging
 
       def initialize(options = {})
         options[:host] ||= HOST
@@ -22,7 +22,7 @@ module Segment
         @path = options[:path] || PATH
         @retries = options[:retries] || RETRIES
         @backoff_policy =
-          options[:backoff_policy] || Segment::Analytics::BackoffPolicy.new
+          options[:backoff_policy] || SegmentIO::Analytics::BackoffPolicy.new
 
         http = Net::HTTP.new(options[:host], options[:port])
         http.use_ssl = options[:ssl]

--- a/lib/segment_io/analytics/utils.rb
+++ b/lib/segment_io/analytics/utils.rb
@@ -1,6 +1,6 @@
 require 'securerandom'
 
-module Segment
+module SegmentIO
   class Analytics
     module Utils
       extend self

--- a/lib/segment_io/analytics/version.rb
+++ b/lib/segment_io/analytics/version.rb
@@ -1,4 +1,4 @@
-module Segment
+module SegmentIO
   class Analytics
     VERSION = '2.4.0'
   end

--- a/lib/segment_io/analytics/worker.rb
+++ b/lib/segment_io/analytics/worker.rb
@@ -1,14 +1,14 @@
-require 'segment/analytics/defaults'
-require 'segment/analytics/message_batch'
-require 'segment/analytics/transport'
-require 'segment/analytics/utils'
+require 'segment_io/analytics/defaults'
+require 'segment_io/analytics/message_batch'
+require 'segment_io/analytics/transport'
+require 'segment_io/analytics/utils'
 
-module Segment
+module SegmentIO
   class Analytics
     class Worker
-      include Segment::Analytics::Utils
-      include Segment::Analytics::Defaults
-      include Segment::Analytics::Logging
+      include SegmentIO::Analytics::Utils
+      include SegmentIO::Analytics::Defaults
+      include SegmentIO::Analytics::Logging
 
       # public: Creates a new worker
       #

--- a/spec/isolated/json_example.rb
+++ b/spec/isolated/json_example.rb
@@ -1,6 +1,6 @@
 RSpec.shared_examples 'message_batch_json' do
   it 'MessageBatch generates proper JSON' do
-    batch = Segment::Analytics::MessageBatch.new(100)
+    batch = SegmentIO::Analytics::MessageBatch.new(100)
     batch << { 'a' => 'b' }
     batch << { 'c' => 'd' }
 

--- a/spec/segment_io/analytics/backoff_policy_spec.rb
+++ b/spec/segment_io/analytics/backoff_policy_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-module Segment
+module SegmentIO
   class Analytics
     describe BackoffPolicy do
       describe '#initialize' do

--- a/spec/segment_io/analytics/client_spec.rb
+++ b/spec/segment_io/analytics/client_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-module Segment
+module SegmentIO
   class Analytics
     describe Client do
       let(:client) do

--- a/spec/segment_io/analytics/message_batch_spec.rb
+++ b/spec/segment_io/analytics/message_batch_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-module Segment
+module SegmentIO
   class Analytics
     describe MessageBatch do
       subject { described_class.new(100) }

--- a/spec/segment_io/analytics/response_spec.rb
+++ b/spec/segment_io/analytics/response_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-module Segment
+module SegmentIO
   class Analytics
     describe Response do
       describe '#status' do

--- a/spec/segment_io/analytics/test_queue_spec.rb
+++ b/spec/segment_io/analytics/test_queue_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-module Segment
+module SegmentIO
   class Analytics
     describe TestQueue do
       let(:test_queue) { described_class.new }

--- a/spec/segment_io/analytics/transport_spec.rb
+++ b/spec/segment_io/analytics/transport_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-module Segment
+module SegmentIO
   class Analytics
     describe Transport do
       before do
@@ -48,7 +48,7 @@ module Segment
 
           it 'sets a default backoff policy' do
             backoff_policy = subject.instance_variable_get(:@backoff_policy)
-            expect(backoff_policy).to be_a(Segment::Analytics::BackoffPolicy)
+            expect(backoff_policy).to be_a(SegmentIO::Analytics::BackoffPolicy)
           end
 
           it 'initializes a new Net::HTTP with default host and port' do

--- a/spec/segment_io/analytics/worker_spec.rb
+++ b/spec/segment_io/analytics/worker_spec.rb
@@ -1,16 +1,16 @@
 require 'spec_helper'
 
-module Segment
+module SegmentIO
   class Analytics
     describe Worker do
       before do
-        Segment::Analytics::Transport.stub = true
+        SegmentIO::Analytics::Transport.stub = true
       end
 
       describe '#init' do
         it 'accepts string keys' do
           queue = Queue.new
-          worker = Segment::Analytics::Worker.new(queue,
+          worker = SegmentIO::Analytics::Worker.new(queue,
                                                   'secret',
                                                   'batch_size' => 100)
           batch = worker.instance_variable_get(:@batch)
@@ -20,36 +20,36 @@ module Segment
 
       describe '#run' do
         before :all do
-          Segment::Analytics::Defaults::Request::BACKOFF = 0.1
+          SegmentIO::Analytics::Defaults::Request::BACKOFF = 0.1
         end
 
         after :all do
-          Segment::Analytics::Defaults::Request::BACKOFF = 30.0
+          SegmentIO::Analytics::Defaults::Request::BACKOFF = 30.0
         end
 
         it 'does not error if the request fails' do
           expect do
-            Segment::Analytics::Transport
+            SegmentIO::Analytics::Transport
               .any_instance
               .stub(:send)
-              .and_return(Segment::Analytics::Response.new(-1, 'Unknown error'))
+              .and_return(SegmentIO::Analytics::Response.new(-1, 'Unknown error'))
 
             queue = Queue.new
             queue << {}
-            worker = Segment::Analytics::Worker.new(queue, 'secret')
+            worker = SegmentIO::Analytics::Worker.new(queue, 'secret')
             worker.run
 
             expect(queue).to be_empty
 
-            Segment::Analytics::Transport.any_instance.unstub(:send)
+            SegmentIO::Analytics::Transport.any_instance.unstub(:send)
           end.to_not raise_error
         end
 
         it 'executes the error handler if the request is invalid' do
-          Segment::Analytics::Transport
+          SegmentIO::Analytics::Transport
             .any_instance
             .stub(:send)
-            .and_return(Segment::Analytics::Response.new(400, 'Some error'))
+            .and_return(SegmentIO::Analytics::Response.new(400, 'Some error'))
 
           status = error = nil
           on_error = proc do |yielded_status, yielded_error|
@@ -67,7 +67,7 @@ module Segment
           sleep 0.1 # First give thread time to spin-up.
           sleep 0.01 while worker.is_requesting?
 
-          Segment::Analytics::Transport.any_instance.unstub(:send)
+          SegmentIO::Analytics::Transport.any_instance.unstub(:send)
 
           expect(queue).to be_empty
           expect(status).to eq(400)
@@ -118,22 +118,22 @@ module Segment
       describe '#is_requesting?' do
         it 'does not return true if there isn\'t a current batch' do
           queue = Queue.new
-          worker = Segment::Analytics::Worker.new(queue, 'testsecret')
+          worker = SegmentIO::Analytics::Worker.new(queue, 'testsecret')
 
           expect(worker.is_requesting?).to eq(false)
         end
 
         it 'returns true if there is a current batch' do
-          Segment::Analytics::Transport
+          SegmentIO::Analytics::Transport
             .any_instance
             .stub(:send) {
               sleep(0.2)
-              Segment::Analytics::Response.new(200, 'Success')
+              SegmentIO::Analytics::Response.new(200, 'Success')
             }
 
           queue = Queue.new
           queue << Requested::TRACK
-          worker = Segment::Analytics::Worker.new(queue, 'testsecret')
+          worker = SegmentIO::Analytics::Worker.new(queue, 'testsecret')
 
           worker_thread = Thread.new { worker.run }
           eventually { expect(worker.is_requesting?).to eq(true) }
@@ -141,7 +141,7 @@ module Segment
           worker_thread.join
           expect(worker.is_requesting?).to eq(false)
 
-          Segment::Analytics::Transport.any_instance.unstub(:send)
+          SegmentIO::Analytics::Transport.any_instance.unstub(:send)
         end
       end
     end

--- a/spec/segment_io/analytics_spec.rb
+++ b/spec/segment_io/analytics_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-module Segment
+module SegmentIO
   class Analytics
     describe Analytics do
-      let(:analytics) { Segment::Analytics.new :write_key => WRITE_KEY, :stub => true }
+      let(:analytics) { SegmentIO::Analytics.new :write_key => WRITE_KEY, :stub => true }
 
       describe '#track' do
         it 'errors without an event' do
@@ -115,13 +115,13 @@ module Segment
       end
 
       describe '#respond_to?' do
-        it 'responds to all public instance methods of Segment::Analytics::Client' do
-          expect(analytics).to respond_to(*Segment::Analytics::Client.public_instance_methods(false))
+        it 'responds to all public instance methods of SegmentIO::Analytics::Client' do
+          expect(analytics).to respond_to(*SegmentIO::Analytics::Client.public_instance_methods(false))
         end
       end
 
       describe '#method' do
-        Segment::Analytics::Client.public_instance_methods(false).each do |public_method|
+        SegmentIO::Analytics::Client.public_instance_methods(false).each do |public_method|
           it "returns a Method object with '#{public_method}' as argument" do
             expect(analytics.method(public_method).class).to eq(Method)
           end
@@ -130,7 +130,7 @@ module Segment
 
       describe '#test_queue' do
         context 'when not in mode' do
-          let(:analytics) { Segment::Analytics.new :write_key => WRITE_KEY, :stub => true, :test => true }
+          let(:analytics) { SegmentIO::Analytics.new :write_key => WRITE_KEY, :stub => true, :test => true }
 
           it 'returns TestQueue' do
             expect(analytics.test_queue).to be_a(TestQueue)
@@ -144,7 +144,7 @@ module Segment
         end
 
         context 'when not in test mode' do
-          let(:analytics) { Segment::Analytics.new :write_key => WRITE_KEY, :stub => true, :test => false }
+          let(:analytics) { SegmentIO::Analytics.new :write_key => WRITE_KEY, :stub => true, :test => false }
 
           it 'errors when not in test mode' do
             expect(analytics.instance_variable_get(:@test)).to be_falsey

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,13 +4,13 @@ SimpleCov.start
 require 'codecov'
 SimpleCov.formatter = SimpleCov::Formatter::Codecov
 
-require 'segment/analytics'
+require 'segment_io/analytics'
 require 'active_support/time'
 
 # Setting timezone for ActiveSupport::TimeWithZone to UTC
 Time.zone = 'UTC'
 
-module Segment
+module SegmentIO
   class Analytics
     WRITE_KEY = 'testsecret'
 


### PR DESCRIPTION
- PR objective: Refactor the gem to allow use of SegmentIO namespace to prevent conflicts

- Changes:
  - Replaces all segment mentions to Segment::IO through the use of the build.sh script
- How to install: bundle install
- How to test locally: bundle exec rspec spec
- How to test using rails application
  - add the following line to gemfile: 
  - `gem 'analytics-ruby', '~> 2.4.0', require: false, git: 'https://github.com/Junglescout/analytics-ruby.git', branch: 'feat/segment-io-renaming'`